### PR TITLE
Fixed a typo in the dropdown label

### DIFF
--- a/01-Mement-O-Matic.ipynb
+++ b/01-Mement-O-Matic.ipynb
@@ -92,7 +92,7 @@
     "         ),\n",
     "         cdx_service = widgets.Dropdown(\n",
     "             options=[\n",
-    "                 ('MemGator (memgator.cs.udo.edu) [RECOMMENDED]', 'https://memgator.cs.odu.edu/timemap/json/'),\n",
+    "                 ('MemGator @ ODU (memgator.cs.odu.edu) [RECOMMENDED]', 'https://memgator.cs.odu.edu/timemap/json/'),\n",
     "                 ('MementoWeb (timetravel.mementoweb.org)', 'https://timetravel.mementoweb.org/api/json/')\n",
     "             ],\n",
     "             description=\"Memento Aggregator Service:\",\n",


### PR DESCRIPTION
`udo` => `odu`
`MemGator` => `MemGator @ ODU`